### PR TITLE
Copy resource files to dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Task targets, files and options may be specified according to the Grunt [Configu
 | cordova:plugin        | Run `cordova plugin` command.                                |
 
 
-### Package files Task
+### Package files Task (Android and iOS only)
 _Run this task with the `grunt cordova:package-files` or `grunt cordova:package` command._
 
 Copy *.apk or *.app to `dist` directory, if run `cordova:package-files` or `cordova:package` task.
@@ -71,6 +71,45 @@ Copy to dist/ios/device/HelloCordova.ipa.
 
 Done, without errors.
 ```
+
+
+#### Post sign script
+If you run `cordova:package` and `cordova:package-files` task, post sign script generated.
+
+
+##### Android
+Generate a private key.
+
+```
+keytool -genkey -v -keystore ~/HelloCordova.keystore -alias HelloCordova -keyalg RSA -keysize 2048 -validity 10000
+chmod 600 ~/HelloCordova.keystore
+```
+
+Create a config file. (./resources/android/config)
+
+```
+KEYSTORE=~/HelloCordova.keystore
+KEYALIAS=HelloCordova
+```
+
+Run `cordova:package` task.
+
+```
+grunt cordova:package --cordova-platforms=android --cordova-release=release
+```
+
+Run post sign script.
+
+```
+./dist/android/distribute
+Enter Passphrase for keystore: ******
+
+...
+
+Verification succesful
+```
+
+`dist/android/CordovaApp-release.apk` is created.
 
 
 ### Cordova Platform Task

--- a/README.md
+++ b/README.md
@@ -112,6 +112,57 @@ Verification succesful
 `dist/android/CordovaApp-release.apk` is created.
 
 
+##### iOS
+Modify cordova iOS platform `platforms/ios/cordova/build-release.xcconfig`. Comment `CODE_SIGN_*`.
+
+```
+...
+
+//
+// XCode Build settings for "Release" Build Configuration.
+//
+
+#include "build.xcconfig"
+
+//CODE_SIGN_IDENTITY = iPhone Distribution
+//CODE_SIGN_IDENTITY[sdk=iphoneos*] = iPhone Distribution
+```
+
+Download distribution provisioning profile from [Member Center Provisioning Profiles](https://developer.apple.com/account/ios/profile/profileList.action?type=production). And copy to `./resources/mobileprovisions/release.mobileprovision`.
+
+```
+mkdir -p ./resources/mobileprovisions
+cp ~/Download/distribution.mobileprovision ./resources/mobileprovisions/release.mobileprovision
+```
+
+Run `cordova:package` task.
+
+```
+grunt cordova:package --cordova-platforms=ios --cordova-build=release --cordova-device=device
+```
+
+Run post sign script.
+
+```
+./dist/ios/distribute
+
+...
+
+Results at '/path/to/project/dist/ios/HelloCordova.ipa'
+```
+
+`dist/ios/HelloCordova.ipa` is created.
+
+If you want to use the other provisioning profiles, you can use the "--mobileprovision" argument.
+
+```
+cp ~/Download/adhoc.mobileprovision ./resources/mobileprovisions/adhoc.mobileprovision
+grunt cordova:package --cordova-platforms=ios --cordova-build=release --cordova-device=device
+
+./dist/ios/distribute --mobileprovision=adhoc
+```
+
+
 ### Cordova Platform Task
 _Run this task with the `grunt cordova:platform` command._
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ KEYALIAS=HelloCordova
 Run `cordova:package` task.
 
 ```
-grunt cordova:package --cordova-platforms=android --cordova-release=release
+grunt cordova:package --cordova-platforms=android --cordova-build=release
 ```
 
 Run post sign script.

--- a/resources/root/distribute
+++ b/resources/root/distribute
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+WORK_DIR=`dirname $0`
+
+for script in ${WORK_DIR}/*/distribute; do
+echo $script
+  if [ -x $script ]; then
+    $script
+  fi
+done


### PR DESCRIPTION
Using `package-files` task, copy resource files to dist.

- copy sign script to dist directory.
- copy keyfile to dist directory.