### PR TITLE
Cannot build ios/device.

### DIFF
--- a/lib/packages/ios.js
+++ b/lib/packages/ios.js
@@ -30,7 +30,7 @@ var xcrunPackage = function (util, source, destination, callback) {
   var args = [
     '-sdk',
     'iphoneos',
-    'PackageApplicationFixed',
+    'PackageApplication',
     path.join(process.cwd(), source),
     '-o',
     path.join(process.cwd(), ipaPath)


### PR DESCRIPTION
Cannot build ios/device.

```
$ yo graybullet-cordova
...
$ grunt build --cordova-platforms=ios --cordova-device=device
...
Running "cordova:package-files" (cordova) task
Copy to dist/ios/device/HelloCordova.ipa.
Warning: Command failed: xcrun: error: unable to find utility "PackageApplicationFixed", not a developer tool or in PATH
 Use --force to continue.

Aborted due to warnings.


Execution Time (2015-01-05 04:54:27 UTC)
loading tasks           1.4s  ▇▇▇▇▇▇ 15%
wiredep:app            210ms  ▇ 2%
concurrent:dist         2.8s  ▇▇▇▇▇▇▇▇▇▇▇▇ 30%
cssmin:generated       148ms  ▇ 2%
uglify:generated        1.5s  ▇▇▇▇▇▇▇ 16%
cordova:build           2.5s  ▇▇▇▇▇▇▇▇▇▇▇ 27%
cordova:package-files  504ms  ▇▇▇ 5%
Total 9.3s
```