### PR TITLE
Stop cordova:package-files task with firefox platfrom

### DIFF
--- a/lib/findPackage.js
+++ b/lib/findPackage.js
@@ -7,8 +7,11 @@ var getPackageFunction = function (platform) {
 
   return platform.match(/^android|ios$/) ?
     require('./packages/' + platform) :
-    function (grunt) {
+    function (grunt, options, callback) {
       grunt.log.warn('Cannot support ' + platform + ' platform.');
+
+      // Unsupported platform is ran, but not error.
+      callback();
     };
 };
 


### PR DESCRIPTION
Stop cordova:package-files task with firefox platform

```
$ grunt cordova:package
Running "cordova:package" (cordova) task

Running "cordova:build" (cordova) task
Cleaning Firefoxos project
Firefox OS packaged app built in platforms/firefoxos/build/package.zip

Running "cordova:package-files" (cordova) task
>> Cannot support firefoxos platform.     <--- Stop this line
```
