### PR TITLE
Fix don't copy apk files with Gradle.

### DIFF
--- a/lib/packages/android.js
+++ b/lib/packages/android.js
@@ -1,10 +1,10 @@
-module.exports = function (grunt, options, callback) {
+var copyApks = function (grunt, options, path) {
   'use strict';
 
   var util = require('./util')(grunt,
                                options,
                                'android',
-                               'ant-build');
+                               path);
 
   var build = options.build || 'debug';
 
@@ -16,6 +16,13 @@ module.exports = function (grunt, options, callback) {
     .forEach(function (file) {
       util.copySync(file, file);
     });
+};
+
+module.exports = function (grunt, options, callback) {
+  'use strict';
+
+  copyApks(grunt, options, 'ant-build'); // ant build.
+  copyApks(grunt, options, 'build/outputs/apk'); // Gradle build.
 
   callback();
 };


### PR DESCRIPTION
If create cordova platform by cordova-android@4.0.0, it using Gradle build. Don't copy apk files.